### PR TITLE
Fix for inverted ILI9342 Displays

### DIFF
--- a/src/bb_spi_lcd.cpp
+++ b/src/bb_spi_lcd.cpp
@@ -2427,9 +2427,13 @@ start_of_init:
        break;
     case LCD_ILI9342:
 	{
-	s = (unsigned char *)uc320InitList;
-        memcpy_P(d, s, sizeof(uc320InitList));
+	s = (unsigned char *)uc240InitList;
+        memcpy_P(d, s, sizeof(uc240InitList));
         s = d;
+        if (pLCD->iLCDFlags & FLAGS_INVERT)
+            s[52] = 0x21; // invert pixels
+        else
+            s[52] = 0x20; // non-inverted
         pLCD->iCMDType = CMD_TYPE_SITRONIX_8BIT;
         pLCD->iCurrentWidth = pLCD->iWidth = 320;
         pLCD->iCurrentHeight = pLCD->iHeight = 240;


### PR DESCRIPTION
I tested the code on an ESP32-S3-BOX3 with an ILI9342 display and noticed the display was inverted. Also, the flag to fix the display inversion didn’t work. This commit fixes that issue, so the display shows up correctly now.